### PR TITLE
Use PBKDF2 hash stretching 

### DIFF
--- a/model/stretch.go
+++ b/model/stretch.go
@@ -3,9 +3,10 @@ package model
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"io"
 	"math/rand"
 	"time"
+
+	"golang.org/x/crypto/pbkdf2"
 )
 
 var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -16,12 +17,7 @@ func init() {
 
 // Stretch makes stretched password using salt.
 func Stretch(password, salt string) string {
-	var b []byte
-	s := sha256.New()
-	for i := 0; i < 1000; i++ {
-		io.WriteString(s, string(b)+password+salt)
-		b = s.Sum(nil)
-	}
+	b := pbkdf2.Key([]byte(password), []byte(salt), 16384, 32, sha256.New)
 	return base64.StdEncoding.EncodeToString(b)
 }
 

--- a/model/stretch_test.go
+++ b/model/stretch_test.go
@@ -5,8 +5,9 @@ import "testing"
 func TestStretch(t *testing.T) {
 	password := "test"
 	salt := "塩"
+	want := "x2SLvhmxOaV2enRmd678M2VFkwZBmYKuHvU369oGoKI="
 	s := Stretch(password, salt)
-	if exp := "Y9SA/lgzzns9Tjt474at6mAC7YXhnSeYt5tjxd4BPrM="; s != exp {
+	if exp := want; s != exp {
 		t.Fatalf("want %s, got %s", exp, s)
 	}
 }


### PR DESCRIPTION
See below for details (Japanese):
https://www.sophos.com/ja-jp/press-office/press-releases/2013/11/ns-serious-security-how-to-store-your-users-passwords-safely.aspx.