### PR TITLE
readme: add db migration before make run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ For local development,
 
 If you using docker, it's easy to work with Elastic stack and fluentd!
 
+    # database migration
+    make migrate/up
     # running docker containers by `docker-compose up -d`
     make run
 


### PR DESCRIPTION
# 問題
指示通り `make run` をしたあと
- http://localhost を開いたときに `no such table: articles` と出る
- ユーザーの登録もできない

# 修正
-  `make run` の前にDBのマイグレーション (`make migrate/up`) をする指示をREADMEに追加